### PR TITLE
Kubernetes Deployment via CLI

### DIFF
--- a/kube-model.yaml
+++ b/kube-model.yaml
@@ -1,0 +1,32 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: caption-generator-deployment
+spec:
+  selector:
+    matchLabels:
+      app: caption-generator
+  replicas: 1
+  template: 
+    metadata:
+      labels:
+        app: caption-generator
+    spec:
+      containers:
+      - name: caption-generator
+        image: codait/max-image-caption-generator:latest
+        ports:
+        - containerPort: 5000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: caption-generator-service
+  name: caption-generator-service
+spec:
+  ports:    
+    - port: 5000 
+  selector:
+    app: caption-generator
+  type: LoadBalancer

--- a/kube-web.yaml
+++ b/kube-web.yaml
@@ -1,0 +1,33 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: caption-generator-web-deployment
+spec:
+  selector:
+    matchLabels:
+      app: caption-generator-web
+  replicas: 1
+  template: 
+    metadata:
+      labels:
+        app: caption-generator-web
+    spec:
+      containers:
+      - name: caption-generator-web
+        image: nheidloff/caption-generator-web:latest
+        command: ["python", "app.py", "--ml-endpoint=http://caption-generator-service:5000"]
+        ports:
+        - containerPort: 8088
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: caption-generator-web-service
+  name: caption-generator-web-service
+spec:
+  ports:    
+    - port: 8088
+  selector:
+    app: caption-generator-web
+  type: LoadBalancer


### PR DESCRIPTION
Added two files to deploy the model as well as the web application to Kubernetes.

If accepted, you could extend README.md with these commands:

kubectl apply -f kube-model.yaml 

docker build -t nheidloff/caption-generator-web . // change Docker account
docker push nheidloff/caption-generator-web // change Docker account

kubectl apply -f kube-web.yaml // change Docker account in kube-web.yaml