### PR TITLE
Update Steps in README to use Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,9 @@ To run the docker image, which automatically starts the model serving API, run:
 
     docker run -it -p 5000:5000 codait/max-image-caption-generator
 
-This will pull the latest docker image available on Docker Hub to run. If you'd rather build the model locally you can
-follow the steps in the model [README](https://github.com/IBM/MAX-Image-Caption-Generator/blob/master/README.md#steps).
+This will pull a pre-built image from Docker Hub (or use an existing image if already cached locally) and run it.
+If you'd rather build the model locally you can follow the steps in the
+[model README](https://github.com/IBM/MAX-Image-Caption-Generator/blob/master/README.md#steps).
 
 _Note_ that currently this docker image is CPU only (we will add support for GPU images later).
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ network stack. This is done in the following steps:
 Modify the command that runs the Image Caption Generator REST endpoint to map an additional port in the container to a
 port on the host machine. In the example below it is mapped to port `8088` on the host but other ports can also be used.
 
-    docker run -it -p 5000:5000 -p 8088:8088 --name max-im2txt codait/max-image-caption-generator
+    docker run -it -p 5000:5000 -p 8088:8088 --name image-caption-generator codait/max-image-caption-generator
 
 Build the web app image by running:
 
@@ -226,13 +226,13 @@ Build the web app image by running:
 
 Run the web app container using:
 
-    docker run --net='container:max-im2txt' -it webapp
+    docker run --net='container:image-caption-generator' -it webapp
 
 ##### Using the Docker Hub Image
 
 You can also deploy the web app with the latest docker image available on DockerHub by running:
 
-    docker run --net='container:max-im2txt' -it codait/max-image-caption-generator-web-app
+    docker run --net='container:image-caption-generator' -it codait/max-image-caption-generator-web-app
 
 This will use the model docker container run above and can be run without cloning the web app repo locally.
 

--- a/README.md
+++ b/README.md
@@ -226,11 +226,11 @@ port on the host machine. In the example below it is mapped to port `8088` on th
 
 Build the web app image by running:
 
-    docker build -t web-app .
+    docker build -t max-image-caption-generator-web-app .
 
 Run the web app container using:
 
-    docker run --net='container:max-image-caption-generator' -it web-app
+    docker run --net='container:max-image-caption-generator' -it max-image-caption-generator-web-app
 
 ##### Using the Docker Hub Image
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ network stack. This is done in the following steps:
 Modify the command that runs the Image Caption Generator REST endpoint to map an additional port in the container to a
 port on the host machine. In the example below it is mapped to port `8088` on the host but other ports can also be used.
 
-    docker run -it -p 5000:5000 -p 8088:8088 --name image-caption-generator codait/max-image-caption-generator
+    docker run -it -p 5000:5000 -p 8088:8088 --name max-image-caption-generator codait/max-image-caption-generator
 
 Build the web app image by running:
 
@@ -226,13 +226,13 @@ Build the web app image by running:
 
 Run the web app container using:
 
-    docker run --net='container:image-caption-generator' -it webapp
+    docker run --net='container:max-image-caption-generator' -it webapp
 
 ##### Using the Docker Hub Image
 
 You can also deploy the web app with the latest docker image available on DockerHub by running:
 
-    docker run --net='container:image-caption-generator' -it codait/max-image-caption-generator-web-app
+    docker run --net='container:max-image-caption-generator' -it codait/max-image-caption-generator-web-app
 
 This will use the model docker container run above and can be run without cloning the web app repo locally.
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,8 @@ The model will only be available internally, but can be accessed externally thro
 
 #### Setting up the MAX Model
 
-1. [Build the Model](#1-build-the-model)
-2. [Deploy the Model](#2-deploy-the-model)
-3. [Experimenting with the API (Optional)](#3-experimenting-with-the-api-optional)
+1. [Deploy the Model](#1-deploy-the-model)
+2. [Experimenting with the API (Optional)](#2-experimenting-with-the-api-optional)
 
 #### Starting the Web App
 
@@ -128,31 +127,18 @@ The model will only be available internally, but can be accessed externally thro
 > NOTE: The set of instructions in this section are a modified version of the one found on the
 [Image Caption Generator Project Page](https://github.com/IBM/MAX-Image-Caption-Generator)
 
-#### 1. Build the Model
-
-Clone the Image Caption Generator model locally. In a terminal, run the following command:
-
-    git clone https://github.com/IBM/MAX-Image-Caption-Generator.git
-
-Change directory into the repository base folder:
-
-    cd MAX-Image-Caption-Generator
-
-To build the docker image locally, run:
-
-    docker build -t max-im2txt .
-
-All required model assets will be downloaded during the build process.
-
-_Note_ that currently this docker image is CPU only (we will add support for GPU images later).
-
-#### 2. Deploy the Model
+#### 1. Deploy the Model
 
 To run the docker image, which automatically starts the model serving API, run:
 
-    docker run -it -p 5000:5000 max-im2txt
+    docker run -it -p 5000:5000 codait/max-image-caption-generator
 
-#### 3. Experimenting with the API (Optional)
+This will pull the latest docker image available on Docker Hub to run. If you'd rather build the model locally you can
+follow the steps in the model [README](https://github.com/IBM/MAX-Image-Caption-Generator/blob/master/README.md#steps).
+
+_Note_ that currently this docker image is CPU only (we will add support for GPU images later).
+
+#### 2. Experimenting with the API (Optional)
 
 The API server automatically generates an interactive Swagger documentation page.
 Go to `http://localhost:5000` to load it. From there you can explore the API and also create test requests.
@@ -161,7 +147,7 @@ Use the `model/predict` endpoint to load a test file and get captions for the im
 
 You can also test it on the command line, for example:
 
-    curl -F "image=@assets/surfing.jpg" -X POST http://localhost:5000/model/predict
+    curl -F "image=@path/to/image.jpg" -X POST http://localhost:5000/model/predict
 
 ```json
 {
@@ -232,7 +218,7 @@ network stack. This is done in the following steps:
 Modify the command that runs the Image Caption Generator REST endpoint to map an additional port in the container to a
 port on the host machine. In the example below it is mapped to port `8088` on the host but other ports can also be used.
 
-    docker run -it -p 5000:5000 -p 8088:8088 --name max-im2txt max-im2txt
+    docker run -it -p 5000:5000 -p 8088:8088 --name max-im2txt codait/max-image-caption-generator
 
 Build the web app image by running:
 
@@ -241,6 +227,14 @@ Build the web app image by running:
 Run the web app container using:
 
     docker run --net='container:max-im2txt' -it webapp
+
+##### Using the Docker Hub Image
+
+You can also deploy the web app with the latest docker image available on DockerHub by running:
+
+    docker run --net='container:max-im2txt' -it codait/max-image-caption-generator-web-app
+
+This will use the model docker container run above and can be run without cloning the web app repo locally.
 
 # Sample Output
 

--- a/README.md
+++ b/README.md
@@ -146,12 +146,12 @@ Go to `http://localhost:5000` to load it. From there you can explore the API and
 
 Use the `model/predict` endpoint to load a test file and get captions for the image from the API.
 
+The [model assets folder](https://github.com/IBM/MAX-Image-Caption-Generator/tree/master/assets)
+contains a few images you can use to test out the API, or you can use your own.
+
 You can also test it on the command line, for example:
 
     curl -F "image=@path/to/image.jpg" -X POST http://localhost:5000/model/predict
-
-The [model assets folder](https://github.com/IBM/MAX-Image-Caption-Generator/tree/master/assets)
-contains a few images you can use to test out the API, or you can use your own.
 
 ```json
 {
@@ -226,11 +226,11 @@ port on the host machine. In the example below it is mapped to port `8088` on th
 
 Build the web app image by running:
 
-    docker build -t webapp .
+    docker build -t web-app .
 
 Run the web app container using:
 
-    docker run --net='container:max-image-caption-generator' -it webapp
+    docker run --net='container:max-image-caption-generator' -it web-app
 
 ##### Using the Docker Hub Image
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ You can also test it on the command line, for example:
 
     curl -F "image=@path/to/image.jpg" -X POST http://localhost:5000/model/predict
 
+The [model assets folder](https://github.com/IBM/MAX-Image-Caption-Generator/tree/master/assets)
+contains a few images you can use to test out the API, or you can use your own.
+
 ```json
 {
   "status": "ok",


### PR DESCRIPTION
Given the model is available on Docker Hub we should update the Steps in the README.

This means less code for the user to checkout locally and make more sense in this usecase.

This update is also in line with updating the models with similar changes.