### PR TITLE
Fixed Supported Extensions

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,7 +44,7 @@ logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"),
 static_img_path = "static/img/images/"
 temp_img_prefix = "MAX-"
 image_captions = collections.OrderedDict()
-VALID_EXT = ['png', 'jpg', 'jpeg', 'gif']
+VALID_EXT = ['png', 'jpg', 'jpeg']
 
 
 class MainHandler(web.RequestHandler):

--- a/static/js/webapp.js
+++ b/static/js/webapp.js
@@ -231,7 +231,7 @@ $(function() {
                     set_img_picker();
                 },
                 error: function() {
-                    alert("Must submit a valid file (png, jpeg, jpg, or gif)");
+                    alert("Must submit a valid file (png, jpeg, or jpg)");
                 },
                 complete: function() {
                     $("#file-submit").text("Submit");


### PR DESCRIPTION
A recent commit to the model (https://github.com/IBM/MAX-Image-Caption-Generator/commit/ac2985f7a92120b4520e1d1a7a4113f8beece8ec) added extension checking. This brought up the fact `.gif` files are not actually supported by the model and have always thrown an error. I've update the web app code to match. This does not remove the now redundant error checking since I don't see a reason to.