### PR TITLE
Fix apiVersion

### DIFF
--- a/max-image-caption-generator-web-app.yaml
+++ b/max-image-caption-generator-web-app.yaml
@@ -9,7 +9,7 @@ spec:
   - port: 8088
   type: LoadBalancer
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: max-image-caption-generator-web-app


### PR DESCRIPTION
Deployment on K8 version 16+ fails because resource `Deployment` is no longer defined in `extensions/v1beta1`. See similar PR for reference https://github.com/IBM/MAX-Image-Caption-Generator/pull/58